### PR TITLE
Support regex query matching

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -483,7 +483,7 @@ dependencies = [
 
 [[package]]
 name = "mockito_declarative_server"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "mockito",
  "reqwest",

--- a/test/basic.yml
+++ b/test/basic.yml
@@ -47,3 +47,14 @@
         value: application/vnd.oci.image.layer.v1.tar+gzip
   response:
     body: ./basic/layer1
+
+- request:
+    method: GET
+    path: /somesite
+    query:
+      -
+        parameter: arguments
+        value: .*
+        regex: true
+  response:
+    body: ./basic/strange


### PR DESCRIPTION
Sometimes it's not apparent what value of a query parameter should the
server expect. This case can be encoded using regex.

This change adds regex support for query matchers.